### PR TITLE
search_api_limit can't be larger than 5000

### DIFF
--- a/grafanaSettings.py
+++ b/grafanaSettings.py
@@ -4,6 +4,6 @@ grafana_url = os.getenv('GRAFANA_URL', 'http://localhost:3000')
 token = os.getenv('GRAFANA_TOKEN', 'eyJrIjoidUhaU2ZQQndrWFN3RTVkUnVOQkRka1JoaG9KWFFObEgiLCJuIjoiYWRtaW4iLCJpZCI6MX0=')
 http_get_headers = {'Authorization': 'Bearer ' + token}
 http_post_headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
-search_api_limit = 100000
+search_api_limit = 5000
 debug = True
 verifySSL = False


### PR DESCRIPTION
The search_api_limit must not be larger than 5000 since April this year (https://github.com/grafana/grafana/pull/16458). I figured this out today after upgrading grafana to 6.4.4 from 5.something.

Probably we should fix the search_dashboard() at some point to use pagination (for sites with more than 5000 dashboards, folders, datasource).